### PR TITLE
XP above last levelup cant be lower than 0

### DIFF
--- a/applications/dolphin/helpers/dolphin_state.c
+++ b/applications/dolphin/helpers/dolphin_state.c
@@ -94,8 +94,13 @@ uint32_t dolphin_state_xp_above_last_levelup(uint32_t icounter) {
 
     uint8_t level = dolphin_get_level(icounter);
     uint32_t level_threshold = REQUIRED_XP(level);
-    return icounter - level_threshold;
+    uint32_t level_out = icounter - level_threshold;
+    if(level_out < 0) {
+        level_out = 0;
+    }
+    return level_out;
 }
+
 
 uint32_t dolphin_state_xp_to_levelup(uint32_t icounter) {
     if(icounter >= LEVEL_XP_MAX) {


### PR DESCRIPTION
# What's new

- Bugfix for bug that caused the XP above last levelup being negative and showing a large number because of 32bit unsigned integer

# Verification 

- If the passport shows a very large XP above last levelup number, after this fix it should show zero. That may not be exactly right but for this purpose it should be ok.

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
